### PR TITLE
socks: fix connection request

### DIFF
--- a/lib/socks.js
+++ b/lib/socks.js
@@ -368,7 +368,7 @@ class SOCKS extends EventEmitter {
       packet[off++] = name.length;
 
     off += name.copy(packet, off);
-    packet.writeUInt32BE(port, off);
+    packet.writeUInt16BE(port, off);
 
     this.state = SOCKS.states.PROXY;
     this.socket.write(packet);


### PR DESCRIPTION
This fixes an issue when requesting a connection that gives the error message "The value of "offset" is out of range. It must be >= 0 and <= 6. Received 8". The port should use 2 bytes (2 ^ 16 - 1) with a max value of 65535, and not 4 bytes (2 ^ 32 - 1) with a max value of 4294967295. Thus it's necessary to use `writeUInt16BE` instead of `writeUInt32BE`, and will not have the out of range error.
    
References:
- https://en.wikipedia.org/wiki/SOCKS#SOCKS5